### PR TITLE
Update Discord URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To get started, head to https://nact.io
 > Note: Nact currently only able to work on Node 8 and above.
 
 ## How are you using Nact?
-We would love to hear how you're using Nact. If you'd like to send feedback (bad or good) please email Nick Cuthbert at  github@ncthbrt.com or join the [Discord](https://discordapp.com/invite/QyfuN3).
+We would love to hear how you're using Nact. If you'd like to send feedback (bad or good) please email Nick Cuthbert at  github@ncthbrt.com or join the [Discord](https://nact.io/en_uk/community).
 
 ## License
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fncthbrt%2Fnact.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fncthbrt%2Fnact?ref=badge_large)


### PR DESCRIPTION
## Description
The Discord invite link is expired or invalid, I propose it's set to the community page which hosts the Discord embed.


## Related Issue
https://github.com/ncthbrt/nact/issues/78

## Motivation and Context
Easier community outreach

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs

