### PR TITLE
Feature/Add mailbox to supervisor context.

### DIFF
--- a/lib/actor.js
+++ b/lib/actor.js
@@ -136,7 +136,9 @@ class Actor {
     delete this.parent;
     [...this.children.values()].forEach(stop);
     this.stopped = true;
-    setImmediate(() => this.afterStop(this.state));
+
+    const context = this.createContextWithMailbox(this);
+    setImmediate(() => this.afterStop(this.state, context));
   }
 
   processNext () {
@@ -183,20 +185,24 @@ class Actor {
   }
 
   createSupervisionContext (msg, sender, error) {
-    const ctx = this.createContext(this);
+    const ctx = this.createContextWithMailbox(this);
     return { ...ctx, ...SupervisionActions };
   }
 
-  createContext (sender) {
+  createContextWithMailbox(sender) {
+    const ctx = this.createContext(sender);
+    return { ...ctx, mailbox: this.mailbox.toArray() };
+  }
+
+  createContext(sender) {
     return {
-      parent: this.parent.reference,
+      parent: this.parent ? this.parent.reference : undefined,
       path: this.path,
       self: this.reference,
       name: this.name,
       children: new Map(this.childReferences),
       sender,
-      log: this.log,
-      mailbox: this.mailbox.toArray()
+      log: this.log
     };
   }
 

--- a/lib/actor.js
+++ b/lib/actor.js
@@ -99,13 +99,13 @@ class Actor {
   query (message, timeout) {
     this.assertNotStopped();
     assert(timeout !== undefined && timeout !== null);
-    const deffered = new Deferral();
+    const deferred = new Deferral();
 
     timeout = Actor.getSafeTimeout(timeout);
-    const timeoutHandle = setTimeout(() => { deffered.reject(new Error('Query Timeout')); }, timeout);
+    const timeoutHandle = setTimeout(() => { deferred.reject(new Error('Query Timeout')); }, timeout);
     const tempReference = new TemporaryReference(this.system.name);
-    this.system.addTempReference(tempReference, deffered);
-    deffered.promise.then(() => {
+    this.system.addTempReference(tempReference, deferred);
+    deferred.promise.then(() => {
       clearTimeout(timeoutHandle);
       this.system.removeTempReference(tempReference);
     }).catch(() => {
@@ -116,7 +116,7 @@ class Actor {
       message = message(tempReference);
     }
     this.dispatch(message, tempReference);
-    return deffered.promise;
+    return deferred.promise;
   }
 
   childStopped (child) {
@@ -195,7 +195,8 @@ class Actor {
       name: this.name,
       children: new Map(this.childReferences),
       sender,
-      log: this.log
+      log: this.log,
+      mailbox: this.mailbox.toArray()
     };
   }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -66,7 +66,8 @@ declare module 'nact' {
     self: Ref<Msg>,
     name: ActorName,
     children: Map<ActorName, Ref<unknown>>,
-    log: Logger
+    log: Logger,
+    mailbox: Msg[]
   };
 
   export type PersistentActorContext<Msg, ParentRef extends Ref<any>> =

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -66,20 +66,22 @@ declare module 'nact' {
     self: Ref<Msg>,
     name: ActorName,
     children: Map<ActorName, Ref<unknown>>,
-    log: Logger,
-    mailbox: Msg[]
+    log: Logger
   };
 
   export type PersistentActorContext<Msg, ParentRef extends Ref<any>> =
     ActorContext<MSGesture, ParentRef> & { persist: (msg: Msg) => Promise<void> };
 
-  export type SupervisionContext<Msg, ParentRef extends Ref<any>> = ActorContext<Msg, ParentRef> & {
+  export type ActorContextWithMailbox<Msg, ParentRef extends Ref<any>> = ActorContext<Msg, ParentRef> & { mailbox: Msg[] };
+
+  export type SupervisionContext<Msg, ParentRef extends Ref<any>> = ActorContextWithMailbox<Msg, ParentRef> & {
     stop: Symbol,
     stopAll: Symbol,
     escalate: Symbol,
     resume: Symbol,
     reset: Symbol,
-    resetAll: Symbol
+    resetAll: Symbol,
+    mailbox: Msg[]
   };
 
 
@@ -105,7 +107,7 @@ declare module 'nact' {
     onCrash?: SupervisionActorFunc<Msg, ParentRef>,
     initialState?: State,
     initialStateFunc?: (ctx: ActorContext<Msg, ParentRef>) => State,
-    afterStop?: (state: State) => void | Promise<void>
+    afterStop?: (state: State, ctx: ActorContextWithMailbox<Msg, ParentRef>) => void | Promise<void>
   };
 
   export type StatelessActorProps<Msg, ParentRef extends Ref<any>> = Omit<ActorProps<any, Msg, ParentRef>, 'initialState' | 'initialStateFunc' | 'afterStop'>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nact",
-  "version": "7.2.2",
+  "version": "7.2.3",
   "description": "nact ⇒ node.js + actors = your services have never been so µ",
   "main": "lib/index.js",
   "scripts": {

--- a/test/actor.js
+++ b/test/actor.js
@@ -546,10 +546,10 @@ describe('Actor', function () {
         return ctx.escalate;
       };
       const parent = createSupervisor(system, 'test1');
-      const child = spawn(parent, (state = 0, msg, ctx) => {
+      const child = spawn(parent, async (state = 0, msg, ctx) => {
         // Wait for messages to queue up, then fail on msg0
         if (state + 1 === 1) {
-          delay(100);
+          await delay(50);
           throw new Error('Very bad thing');
         }
         dispatch(ctx.sender, state + 1);
@@ -626,6 +626,31 @@ describe('Actor', function () {
       let result2 = await query(child2, 'msg3', 300);
       result.should.equal(1);
       result2.should.equal(1);
+    });
+  });
+
+  describe('#afterStop', function () {
+    let system;
+    beforeEach(() => { system = start(); });
+    afterEach(() => {
+      stop(system);
+      // reset console
+      delete console.error;
+    });
+
+    it('should be able to act on context after stop', async function () {
+      const afterStop = (state, ctx) => {
+        ctx.mailbox.length.should.equal(1);
+        ctx.mailbox[0].message.should.equal(1);
+      }
+
+      const child = spawn(system, async (state = {}, _msg, _ctx) => {
+        await delay(100);
+        return state;
+      }, 'test', { afterStop });
+
+      dispatch(child, 1);
+      stop(child);
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allows onCrash handlers to access the rest of the mailbox through the SupervisorContext.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#80

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently the parameters passed to onCrash don't provide access to the internal queue of messages to handle the messages waiting in the queue before shutting down the actor.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test added to the onCrash tests to check that other messages in the queue are accessible when a message ahead of them in the queue crashes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
