### PR TITLE
Add optional 3rd argument sender to dispatch typing

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -174,7 +174,7 @@ declare module 'nact' {
 
   export function stop(actor: Ref<any>): void;
 
-  export function dispatch<T>(actor: Ref<T>, msg: T): void;
+  export function dispatch<T>(actor: Ref<T>, msg: T, sender?: Ref<T>): void;
 
 
   export type QueryMsgFactory<Req, Res> = (tempRef: Ref<Res>) => Req;


### PR DESCRIPTION
Dispatch accepts a 3rd optional argument, but typing for dispatch does not reflect this.  This PR updates this.

## Description
Update dispatch typing to reflect its ability to accept a 3rd optional argument, sender.

## Related Issue
https://github.com/ncthbrt/nact/issues/86

## Motivation and Context
This allows for importing nact using import statements instead of require with typescript.

## How Has This Been Tested?
Updated the changes here, and then ran repro steps in ticket and found issue to be resolved.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
