### PR TITLE
feat(): adjusts path regex to match RFC1738

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# IDE
+.idea
+
 # Runtime data
 pids
 *.pid

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -6,14 +6,14 @@ class ActorPath {
 
   createChildPath (name) {
     if (!ActorPath.isValidName(name)) {
-      throw new Error('Invalid argument: path may only contain the letters from a-z, dashes and digits');
+      throw new Error('Invalid argument: path may only contain URI encoded characters, RFC1738 alpha, digit, safe, extra');
     }
 
     return new ActorPath([...this.parts, name], this.system);
   }
 
   static isValidName (name) {
-    const actorNameRegex = /^[a-z0-9-_]+$/i;
+    const actorNameRegex = /^[a-z0-9-$_.+!*'(),]+$/i;
     return !!name && typeof (name) === 'string' && !!name.match(actorNameRegex);
   }
 

--- a/test/paths.js
+++ b/test/paths.js
@@ -5,9 +5,25 @@ const { ActorPath } = require('../lib/paths');
 
 describe('Path', function () {
   describe('#isValidName()', function () {
-    it('should disallow non alphanumeric character (and dashes)', function () {
-      ActorPath.isValidName('$').should.be.false;
-      ActorPath.isValidName('frog%').should.be.false;
+    // https://tools.ietf.org/html/rfc1738
+    it('should disallow national, punctuation, reserved, hex, escape characters', function () {
+      ActorPath.isValidName(';').should.be.false;
+      ActorPath.isValidName('/').should.be.false;
+      ActorPath.isValidName('{').should.be.false;
+      ActorPath.isValidName('}').should.be.false;
+      ActorPath.isValidName('\\').should.be.false;
+      ActorPath.isValidName('^').should.be.false;
+      ActorPath.isValidName('`').should.be.false;
+      ActorPath.isValidName('~').should.be.false;
+      ActorPath.isValidName('[').should.be.false;
+      ActorPath.isValidName(']').should.be.false;
+      ActorPath.isValidName('<').should.be.false;
+      ActorPath.isValidName('>').should.be.false;
+      ActorPath.isValidName('#').should.be.false;
+      ActorPath.isValidName('%').should.be.false;
+      ActorPath.isValidName('"').should.be.false;
+      ActorPath.isValidName('?').should.be.false;
+      ActorPath.isValidName('&').should.be.false;
     });
 
     it('should disallow empty names', function () {
@@ -30,12 +46,14 @@ describe('Path', function () {
       ActorPath.isValidName('a a').should.be.false;
     });
 
-    it('should allow names containing only alphanumeric characters and dashes', function () {
+    it('should allow names containing only alpha, digit, safe, extra characters', function () {
       ActorPath.isValidName('frog').should.be.true;
       ActorPath.isValidName('123').should.be.true;
       ActorPath.isValidName('123-abc').should.be.true;
       ActorPath.isValidName('-').should.be.true;
       ActorPath.isValidName('-a-').should.be.true;
+      ActorPath.isValidName('frog.path').should.be.true;
+      ActorPath.isValidName('frog(path)').should.be.true;
     });
   });
 
@@ -52,13 +70,13 @@ describe('Path', function () {
     });
 
     it('should throw an exception if the child name is invalid', function () {
-      (() => ActorPath.root().createChildPath('$')).should.throw(Error);
+      (() => ActorPath.root().createChildPath('?')).should.throw(Error);
       (() => ActorPath.root().createChildPath('a').createChildPath(' ')).should.throw(Error);
       (() => ActorPath.root().createChildPath('a').createChildPath('')).should.throw(Error);
       (() => ActorPath.root().createChildPath(undefined)).should.throw(Error);
       (() => ActorPath.root().createChildPath(null)).should.throw(Error);
       (() => ActorPath.root().createChildPath(123)).should.throw(Error);
-      (() => ActorPath.root().createChildPath('.')).should.throw(Error);
+      (() => ActorPath.root().createChildPath('&')).should.throw(Error);
     });
   });
 });


### PR DESCRIPTION
Allows URI alpha, digit, safe, extra  characters which are not reserved.
- ref: https://tools.ietf.org/html/rfc1738

## Description
A small change to the Path Regex `/^[a-z0-9-$_.+!*'(),]+$/i`.  This allows for Actor Paths to match the RFC1738 standard for each Path Part. When the Actor's Path is joined, it still provides a valid URL allowing for non-reserved characters.  In particular, this regex allows for RFC1738 alpha, digit, safe, extra.

```
alpha          = lowalpha | hialpha
digit          = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" |
                 "8" | "9"
safe           = "$" | "-" | "_" | "." | "+"
extra          = "!" | "*" | "'" | "(" | ")" | ","
```

## Related Issue
This is a discussion from Discord. I Can open issue and link here if required.

## Motivation and Context
This allows Path Parts to be URI compliant when joined using safe characters from RFC1738. I needed to be able to use periods "." in my Actor Paths, which led me to asking why this character was un-allowed.  The reason for the original regex was so that all the paths could be joined into a valid URL.  So this PR fixes that Regex so that it is less restrictive and still maintains the intended output of a URL safe string :fire:.

## How Has This Been Tested?
I used `yarn test` to run all tests on Node 10 and 12
I added tests cases for each of the reserved characters, and adjusted test cases that were restricting the new expression.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [Where is this?] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
