### PR TITLE
feat(): allow for selected PersistenceActor to accept additional options

### DIFF
--- a/lib/persistence/persistent-actor.js
+++ b/lib/persistence/persistent-actor.js
@@ -130,10 +130,10 @@ class PersistentActor extends Actor {
     this.immediate = setImmediate(() => this.recover());
   }
 
-  async persist (msg, tags = []) {
+  async persist (msg, tags = [], ...properties) {
     --this.messagesToNextSnapshot;
     const persistedEvent = new PersistedEvent(this.encoder(msg), ++this.sequenceNumber, this.key, tags);
-    await (this.persistenceEngine.persist(persistedEvent));
+    await (this.persistenceEngine.persist(persistedEvent, ...properties));
   }
 
   createContext () {

--- a/test/mock-persistence-engine-properties.js
+++ b/test/mock-persistence-engine-properties.js
@@ -1,0 +1,51 @@
+const { AbstractPersistenceEngine } = require('../lib/persistence');
+
+class MockPersistenceEngineProperties extends AbstractPersistenceEngine {
+  constructor (events = {}, snapshots = {}, takeSnapshotIsWorking = true, validateSeqNumber = false, annotations = [], metadata = []) {
+    super();
+    this._events = events;
+    this._snapshots = snapshots;
+    this.takeSnapshotIsWorking = takeSnapshotIsWorking;
+    this.validateSeqNumber = validateSeqNumber;
+    this._annotations = annotations;
+    this._metadata = metadata;
+  }
+
+  latestSnapshot (persistenceKey) {
+    const snapshots = (this._snapshots[persistenceKey] || []);
+    const snapshot = snapshots[snapshots.length - 1];
+    return Promise.resolve(snapshot);
+  }
+
+  takeSnapshot (persistedSnapshot) {
+    if (this.takeSnapshotIsWorking) {
+      const prev = this._snapshots[persistedSnapshot.key] || [];
+      this._snapshots[persistedSnapshot.key] = [...prev, persistedSnapshot];
+      return Promise.resolve(persistedSnapshot);
+    } else {
+      return Promise.reject(new Error('Elvis has left the building'));
+    }
+  }
+
+  events (persistenceKey, offset = 0, limit, tags) {
+    const persistedEvents = (this._events[persistenceKey] || []);
+    const slice = persistedEvents.slice(offset, limit ? offset + limit : undefined);
+    return slice;
+  }
+
+  persist (persistedEvent, annotations, metadata) {
+    const prev = this._events[persistedEvent.key] || [];
+
+    let nextEvents = [...prev, persistedEvent];
+    if (this.validateSeqNumber && prev.reduce((prev, current) => prev && current.sequenceNumber !== persistedEvent.sequenceNumber, true)) {
+      return Promise.reject(new Error('Duplicate sequence number'));
+    }
+    this._events[persistedEvent.key] = nextEvents;
+
+    this._annotations = [...this._annotations, annotations];
+    this._metadata = [...this._metadata, metadata];
+    return Promise.resolve(persistedEvent);
+  }
+}
+
+module.exports.MockPersistenceEngineProperties = MockPersistenceEngineProperties;

--- a/test/persistence-engine.js
+++ b/test/persistence-engine.js
@@ -48,7 +48,7 @@ describe('PersistedEvent', function () {
   });
 
   describe('#createdAt', function () {
-    it('should be able to be explicitely set', function () {
+    it('should be able to be explicitly set', function () {
       new PersistedEvent({ msg: 'test' }, 1, 'test-key', [], 123456).createdAt.should.equal(123456);
     });
 


### PR DESCRIPTION
Allows for the Abstract PersistenceActor.persist method to accept an unknown amount of arguments and pass those arguments to the PersistenceEngine.persist method.

## Description
This change allows for `PersistenceActor.persist(msg, tags, additionalProp1, additionalProp2)`. Tags define an array of strings that are helpful to persisted events, however, some persistence engines will want to expand on this capability while maintaining compatibility. This Pull Requests allows them to do so without fragmenting the current core.

## Related Issue
This is based on the conversation from discord.

## Motivation and Context
Since the Persistence Actor is included in the core library, plugin authors may end up forking the core to make a small modification to methods such as `persist`.  This PR allows for backwards compatibility and authors to write adapters that extend the functionality of persist that the project could not have anticipated.

I needed to pass 2 additional params that were environment specific for an event, but should not be stored in the state, and could not be stored in tags. After much consideration and attempts to work around changing the core, it became evident that I would either need to fork the core, or to submit a PR that allows for the additional parameters and help plugin authors such as myself.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
While working on a community adapter for the Persistence Engine, I needed to pass additional parameters to the PersistenceActor persist method.  Bundling Nact with this modification, I was able to test this against the original nact-persistence-postgres library as well as my community library. I then created a new mock persistence engine that tests overloading the persist method, and tested the overload to success and observed prior implementations were still operating as expected. 
 
<!--- Include details of your testing environment, and the tests you ran to -->
I ran yarn test in node v10, v12, and inspected the results of 148 of 148 passing tests. 

<!--- see how your change affects other areas of the code, etc. -->
This change is so minor, that the only effects it will have are: Existing users who already accidentally overloaded the parameters of the persist function are now actually passing those to their selected persistence engine.  If their persistence engine was expecting parameters (which they shouldn't be), those will now be actionable.

## Screenshots (if appropriate):
NA

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
