### PR TITLE
fix(): fixes child supervision by top level actors

### DIFF
--- a/lib/actor.js
+++ b/lib/actor.js
@@ -155,9 +155,9 @@ class Actor {
     }
   }
 
-  async handleFault (msg, sender, error) {
+  async handleFault (msg, sender, error, child = undefined) {
     const ctx = this.createSupervisionContext(msg, sender, error);
-    const decision = await Promise.resolve(this.onCrash(msg, error, ctx));
+    const decision = await Promise.resolve(this.onCrash(msg, error, ctx, child));
     switch (decision) {
       case SupervisionActions.stop:
         this.stop();

--- a/lib/actor.js
+++ b/lib/actor.js
@@ -176,7 +176,7 @@ class Actor {
         break;
       case SupervisionActions.escalate:
       default:
-        this.parent.handleFault(msg, sender, error, this);
+        this.parent.handleFault(msg, sender, error, this.reference);
         break;
     }
   }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -96,7 +96,7 @@ declare module 'nact' {
   export type PersistentActorFunc<State, Msg, ParentRef extends Ref<any>> = (state: State, msg: Msg, ctx: ActorContext<Msg, ParentRef>) =>
     State | Promise<State>;
 
-  export type SupervisionActorFunc<Msg, ParentRef extends Ref<any>> = (msg: Msg | undefined, err: Error | undefined, ctx: SupervisionContext<Msg, ParentRef>) => Symbol | Promise<Symbol>;
+  export type SupervisionActorFunc<Msg, ParentRef extends Ref<any>, ChildRef extends Ref<any>> = (msg: Msg | undefined, err: Error | undefined, ctx: SupervisionContext<Msg, ParentRef>, child: ChildRef | undefined) => Symbol | Promise<Symbol>;
 
   export type PersistentQueryFunc<State, Msg> = (state: State, msg: Msg) => State | Promise<State>;
 
@@ -104,7 +104,7 @@ declare module 'nact' {
   // Actor configuration
   export type ActorProps<State, Msg, ParentRef extends Ref<any>> = {
     shutdownAfter?: Milliseconds,
-    onCrash?: SupervisionActorFunc<Msg, ParentRef>,
+    onCrash?: SupervisionActorFunc<Msg, ParentRef, Ref<any>>,
     initialState?: State,
     initialStateFunc?: (ctx: ActorContext<Msg, ParentRef>) => State,
     afterStop?: (state: State, ctx: ActorContextWithMailbox<Msg, ParentRef>) => void | Promise<void>
@@ -174,13 +174,13 @@ declare module 'nact' {
 
   export function stop(actor: Ref<any>): void;
 
-  /** Note: Sender when using dispatch has been intentionally omitted from the typescript bindings.  
-   *        Sender simply cannot be strongly typed. A safer alternative is to include the sender 
-   *        as part of the message protocol. For example: 
-   *        ``` 
+  /** Note: Sender when using dispatch has been intentionally omitted from the typescript bindings.
+   *        Sender simply cannot be strongly typed. A safer alternative is to include the sender
+   *        as part of the message protocol. For example:
+   *        ```
    *            dispatch(pizzaActor, { sender: deliveryActor, order: ['ONE_LARGE_PEPPERONI']  });
-   *        ``` 
-   */  
+   *        ```
+   */
   export function dispatch<T>(actor: Ref<T>, msg: T): void;
 
 
@@ -265,7 +265,7 @@ declare module 'nact' {
 
   export function configureLogging(engine: LoggingEngine): Plugin;
 
-  // Persistence 
+  // Persistence
   export type PersistedSnapshot = {
     data: Json,
     sequenceNumber: number,
@@ -308,6 +308,6 @@ declare module 'nact' {
 }
 
 // declare module 'nact/monad' {
-//   export abstract class Effect<> { }; 
+//   export abstract class Effect<> { };
 //   export function* start(program: funct): void;
 // }

--- a/lib/supervision.js
+++ b/lib/supervision.js
@@ -10,12 +10,11 @@ const SupervisionActions = {
 const defaultSupervisionPolicy = (msg, err, ctx, child = undefined) => {
   let path = ctx.path.toString();
   if (child) {
-    console.log(`${path}: The following error was escalated when raised by child '${child.name}' processing message %O:\n%O\nTerminating faulted child actor`, msg, err);
-    return child.stop;
+    console.log(`${path}: The following error was escalated when raised by child '${child.name}' processing message %O:\n%O\nTerminating faulted actor`, msg, err);
   } else {
     console.log(`${path}: The following error was raised when processing message %O:\n%O\nTerminating faulted actor`, msg, err);
-    return ctx.stop;
   }
+  return ctx.stop;
 };
 
 module.exports = {

--- a/lib/supervision.js
+++ b/lib/supervision.js
@@ -7,10 +7,15 @@ const SupervisionActions = {
   resetAll: Symbol('resetAll')
 };
 
-const defaultSupervisionPolicy = (msg, err, ctx) => {
+const defaultSupervisionPolicy = (msg, err, ctx, child = undefined) => {
   let path = ctx.path.toString();
-  console.log(`${path}: The following error was raised when processing message %O:\n%O\nTerminating faulted actor`, msg, err);
-  return ctx.stop;
+  if (child) {
+    console.log(`${path}: The following error was escalated when raised by child '${child.name}' processing message %O:\n%O\nTerminating faulted child actor`, msg, err);
+    return child.stop;
+  } else {
+    console.log(`${path}: The following error was raised when processing message %O:\n%O\nTerminating faulted actor`, msg, err);
+    return ctx.stop;
+  }
 };
 
 module.exports = {

--- a/lib/system.js
+++ b/lib/system.js
@@ -62,7 +62,7 @@ class ActorSystem {
 
   handleFault (msg, sender, error, child) {
     console.log('Stopping top level actor,', child.name, 'due to a fault');
-    child.stop();
+    stop(child);
   }
 
   childStopped (child) {

--- a/test/actor.js
+++ b/test/actor.js
@@ -602,7 +602,7 @@ describe('Actor', function () {
     it('should be able to escalate to parent (which stops child and resumes)', async function () {
       const stopChildAndResumeOrEscalate = (msg, err, ctx, _child) => {
         if (_child) {
-          _child.stop();
+          stop(_child);
           return ctx.resume;
         } else {
           return ctx.escalate;

--- a/test/actor.js
+++ b/test/actor.js
@@ -563,7 +563,7 @@ describe('Actor', function () {
       isStopped(parent).should.be.true;
     });
 
-    it('should be able to escalate to system (which stops child)', async function () {
+    it('should be able to escalate to system (which stops child by default)', async function () {
       const escalate = (msg, err, ctx) => ctx.escalate;
       const child = spawn(system, (state = 0, msg, ctx) => {
         if (state + 1 === 3 && msg !== 'msg3') {
@@ -577,6 +577,57 @@ describe('Actor', function () {
       dispatch(child, 'msg2');
       await delay(100);
       isStopped(child).should.be.true;
+    });
+
+    it('should be able to escalate to parent (which escalates to system)', async function () {
+      const escalate = (msg, err, ctx, _child) => ctx.escalate;
+      const parent = spawn(system, (state = 0, msg, ctx) => {
+        throw new Error('Very bad thing');
+      }, 'parent-of-test', { });
+      const child = spawn(parent, (state = 0, msg, ctx) => {
+        if (state + 1 === 3 && msg !== 'msg3') {
+          throw new Error('Very bad thing');
+        }
+        dispatch(ctx.sender, state + 1);
+        return state + 1;
+      }, 'test', { onCrash: escalate });
+      dispatch(child, 'msg0');
+      dispatch(child, 'msg1');
+      dispatch(child, 'msg2');
+      await delay(100);
+      isStopped(child).should.be.true;
+      isStopped(parent).should.be.true;
+    });
+
+    it('should be able to escalate to parent (which stops child and resumes)', async function () {
+      const stopChildAndResumeOrEscalate = (msg, err, ctx, _child) => {
+        if (_child) {
+          _child.stop();
+          return ctx.resume;
+        } else {
+          return ctx.escalate;
+        }
+      };
+      const escalate = (msg, err, ctx) => ctx.escalate;
+      const parent = spawn(system, (state = 0, msg, ctx) => {
+        throw new Error('Very bad thing');
+      }, 'parent-of-test', { onCrash: stopChildAndResumeOrEscalate });
+      const child = spawn(parent, (state = 0, msg, ctx) => {
+        if (state + 1 === 3 && msg !== 'msg3') {
+          throw new Error('Very bad thing');
+        }
+        dispatch(ctx.sender, state + 1);
+        return state + 1;
+      }, 'test', { onCrash: escalate });
+      dispatch(child, 'msg0');
+      dispatch(child, 'msg1');
+      dispatch(child, 'msg2');
+      await delay(100);
+      isStopped(child).should.be.true;
+      isStopped(parent).should.be.false;
+      dispatch(parent, 'parent-msg0');
+      await delay(100);
+      isStopped(parent).should.be.true;
     });
 
     it('should be able to stop all children', async function () {

--- a/test/actor.js
+++ b/test/actor.js
@@ -619,15 +619,20 @@ describe('Actor', function () {
         dispatch(ctx.sender, state + 1);
         return state + 1;
       }, 'test', { onCrash: escalate });
+      const sibling = spawn(parent, (state = 0, msg, ctx) => {
+        throw new Error('Very bad thing');
+      }, 'sibling-of-test', { onCrash: escalate });
       dispatch(child, 'msg0');
       dispatch(child, 'msg1');
       dispatch(child, 'msg2');
       await delay(100);
       isStopped(child).should.be.true;
       isStopped(parent).should.be.false;
+      isStopped(sibling).should.be.false;
       dispatch(parent, 'parent-msg0');
       await delay(100);
       isStopped(parent).should.be.true;
+      isStopped(sibling).should.be.true;
     });
 
     it('should be able to stop all children', async function () {


### PR DESCRIPTION
- fixes default supervision policy to handle child faults from top level actors in the same way that system treats them.
- fixes `handleFault` method to pass child to parent's `handleFault` method

<!--- Provide a general summary of your changes in the Title above -->

## Description
Actors should be able to supervise children actors and make decisions on their behalf much like the system level actor does as described by the project. This PR provides a fix for the intent of fine grained control over faulted individual children which would otherwise just escalate errors until it reaches the system actor which would stop the whole chain down.

This modifies the defaultSupervisionPolicy to accept a child if provided and behave as the system level actor behaves, as well as modifies the Actor Class's `handleFault` method to accept a child parameter.

This means that the onCrash function now takes all 4 parameters just as the system does as intended.

Example:
```js
const onCrash = (msg, err, ctx, child) => {
  if (child) {
    // tell the individual child to stop
    stop(child);
    // tell the parent to continue as if nothing happened
    return ctx.resume 
  }
  else {
    // tell the parent parent this actor faulted
    return ctx.escalate;
  }
}
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
From conversation on Discord, will open issue upon request.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Often when a Top Level Actor receives an error from a child, it will need to respond and decide what should become of the child's state. However, before this fix, when a child of a top level actor faulted, it would just trigger the parent's supervision policy without providing any context of the child that faulted, which didn't allow the parent to decide what to do.  The intent for the supervisor policy is clear, given the context of how the system level actor handles faulted children, however, the Actor class `handleFault` was missing the child parameter. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested parent/child relationship and a parent/child/sibling relationship to ensure that the expected behavior was produced and that current tests/behaviors remained intact.

Env: Node.js v10, and v12 on Mac OS.

## Screenshots (if appropriate):
NA

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
