### PR TITLE
feat(): adds missing supervisor policies

### DIFF
--- a/lib/actor.js
+++ b/lib/actor.js
@@ -159,21 +159,43 @@ class Actor {
     const ctx = this.createSupervisionContext(msg, sender, error);
     const decision = await Promise.resolve(this.onCrash(msg, error, ctx, child));
     switch (decision) {
+      // Stop Self
       case SupervisionActions.stop:
         this.stop();
         break;
+      // Stop Self and Peers
       case SupervisionActions.stopAll:
         [...this.parent.children.values()].forEach(x => x.stop());
         break;
+      // Stop Child
+      case SupervisionActions.stopChild:
+        this.children.get(child.name).stop();
+        break;
+      // Stop All Children
+      case SupervisionActions.stopAllChildren:
+        [...this.children.values()].forEach(x => x.stop());
+        break;
+      // Resume
       case SupervisionActions.resume:
         this.resume();
         break;
+      // Reset Self
       case SupervisionActions.reset:
         this.reset();
         break;
+      // Reset Self and Peers
       case SupervisionActions.resetAll:
         [...this.parent.children.values()].forEach(x => x.reset());
         break;
+      // Reset Child
+      case SupervisionActions.resetChild:
+        this.children.get(child.name).reset();
+        break;
+      // Reset all Children
+      case SupervisionActions.resetAllChildren:
+        [...this.children.values()].forEach(x => x.reset());
+        break;
+      // Escalate to Parent
       case SupervisionActions.escalate:
       default:
         this.parent.handleFault(msg, sender, error, this.reference);

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -77,10 +77,14 @@ declare module 'nact' {
   export type SupervisionContext<Msg, ParentRef extends Ref<any>> = ActorContextWithMailbox<Msg, ParentRef> & {
     stop: Symbol,
     stopAll: Symbol,
+    stopChild: Symbol,
+    stopAllChildren: Symbol,
     escalate: Symbol,
     resume: Symbol,
     reset: Symbol,
     resetAll: Symbol,
+    resetChild: Symbol,
+    resetAllChildren: Symbol,
     mailbox: Msg[]
   };
 

--- a/lib/supervision.js
+++ b/lib/supervision.js
@@ -1,10 +1,24 @@
 const SupervisionActions = {
+  // Stop Self
   stop: Symbol('stop'),
+  // Stop Self and Peers
   stopAll: Symbol('stopAll'),
+  // Stop Faulted Child
+  stopChild: Symbol('stopChild'),
+  // Stop All Children
+  stopAllChildren: Symbol('stopAllChildren'),
+  // Escalate to Parent
   escalate: Symbol('escalate'),
+  // Resume Self
   resume: Symbol('resume'),
+  // Reset Self
   reset: Symbol('reset'),
-  resetAll: Symbol('resetAll')
+  // Reset Self and Peers
+  resetAll: Symbol('resetAll'),
+  // Reset Child
+  resetChild: Symbol('resetChild'),
+  // Reset All Children
+  resetAllChildren: Symbol('resetAllChildren')
 };
 
 const defaultSupervisionPolicy = (msg, err, ctx, child = undefined) => {


### PR DESCRIPTION
Supervision now covers all edges of: One for One, Rest for One, All for One.

Adds Supervision Policies:

- stopChild
- stopAllChildren
- resetChild
- resetAllChildren

This is enabled by the implementation of https://github.com/ncthbrt/nact/pull/96

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds missing Supervision policies:
- stopChild: Stop only the faulted child 
- stopAllChildren: Stop All children because one faulted
- resetChild: Reset only the faulted child
- resetAllChildren: Reset all Children because one faulted

This allows for more fine grained control of the Actor supervision in deeper levels of a hierarchy where it would be impractical to restart entire sections of a system because of a child fault. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
From discussion on Discord

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Supervision Policies should have the ability to handle faulted child Actors in a way that does disrupt the rest of the system. By adding the xChild and xAllChildren methods to both stop and reset, this completes the paradigm.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added several tests to allow for coverage of additional edge cases, and all tests continue to pass.  This is a non-breaking change.  Existing code should experience no unexpected behaviors.

Env: Node.js v10 and v12 on Macos.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
